### PR TITLE
Fix item_type.code attribute name

### DIFF
--- a/ddl2/cif_img.dic
+++ b/ddl2/cif_img.dic
@@ -1417,7 +1417,7 @@ save__array_data_external_data.archive_format
 
     _item.name                 '_array_data_external_data.archive_format'
     _item.category_id            array_data_external_data
-    _item.type_code              code
+    _item_type.code              code
     _item_default.value          .
 
     loop_
@@ -1456,7 +1456,7 @@ save__array_data_external_data.file_compression
     _item.name                 '_array_data_external_data.file_compression'
     _item.category_id            array_data_external_data
     _item.mandatory_code         no
-    _item.type_code              code
+    _item_type.code              code
     _item_default.value          .
 
     loop_


### PR DESCRIPTION
In two definitions `_item.type_code` was used as an attribute name instead of `_item_type.code`